### PR TITLE
fix: JSON Mode when provided through model kwargs

### DIFF
--- a/libs/together/langchain_together/chat_models.py
+++ b/libs/together/langchain_together/chat_models.py
@@ -350,9 +350,8 @@ class ChatTogether(BaseChatOpenAI):
 
         if not (self.client or None):
             sync_specific: dict = {"http_client": self.http_client}
-            self.client = openai.OpenAI(
-                **client_params, **sync_specific
-            ).chat.completions
+            self.root_client = openai.OpenAI(**client_params, **sync_specific)
+            self.client = self.root_client.chat.completions
         if not (self.async_client or None):
             async_specific: dict = {"http_client": self.http_async_client}
             self.async_client = openai.AsyncOpenAI(

--- a/libs/together/tests/integration_tests/test_chat_models.py
+++ b/libs/together/tests/integration_tests/test_chat_models.py
@@ -134,3 +134,23 @@ def test_invoke() -> None:
 
     result = llm.invoke("I'm Pickle Rick", config=dict(tags=["foo"]))
     assert isinstance(result.content, str)
+
+
+def test_invoke_json_mode_through_model_kwargs() -> None:
+    """Test invoke json_model invocation works"""
+    llm = ChatTogether(
+        model="meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
+        model_kwargs={"response_format": {"type": "json_object"}},
+    )
+    result = llm.invoke("I'm Pickle Rick")
+    assert isinstance(result.content, str)
+
+
+def test_invoke_json_mode_through_bind() -> None:
+    """Test invoke json_model invocation works"""
+    llm = ChatTogether(
+        model="meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
+    )
+    llm.bind(response_format={"type": "json_object"})
+    result = llm.invoke("I'm Pickle Rick")
+    assert isinstance(result.content, str)


### PR DESCRIPTION
As you know `model_kwargs` are passed on to OpenAI's `create` method. 

```
llm = ChatTogether(
        model="meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
        model_kwargs={"response_format": {"type": "json_object"}},
    )
``` 
This fails, I have a fix in this PR. Let me know your thoughts. 

References:
- https://docs.together.ai/docs/json-mode