### PR TITLE
Fix a typo in chat_models.py

### DIFF
--- a/libs/together/langchain_together/chat_models.py
+++ b/libs/together/langchain_together/chat_models.py
@@ -48,7 +48,7 @@ class ChatTogether(BaseChatOpenAI):
     Instantiate:
         .. code-block:: python
 
-            from langhcain_together import ChatTogether
+            from langchain_together import ChatTogether
 
             llm = ChatTogether(
                 model="meta-llama/Llama-3-70b-chat-hf",


### PR DESCRIPTION
Just a small typo but it broke the sample code in the doc : https://python.langchain.com/api_reference/together/chat_models/langchain_together.chat_models.ChatTogether.html

Thanks for your amazing works !